### PR TITLE
Generate ePUB version of the book

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,17 +6,27 @@
     },
     "features": {
         "ghcr.io/devcontainers/features/git:1": {},
-        "ghcr.io/eitsupi/devcontainer-features/mdbook:1": {}
+        "ghcr.io/devcontainers/features/rust:1": {
+            "version": "1.82.0"
+        },
+        "ghcr.io/eitsupi/devcontainer-features/mdbook:1": {},
+        "./mdbook-epub": {}
     },
     "customizations": {
         "vscode": {
             "extensions": [
                 "ms-azuretools.vscode-docker",
-                "tamasfe.even-better-toml"
+                "tamasfe.even-better-toml",
+                "vadimcn.vscode-lldb",
+                "rust-lang.rust-analyzer",
+                "tamasfe.even-better-toml",
+                "DavidAnson.vscode-markdownlint",
+                "codezombiech.gitignore"
             ]
         }
     },
     "forwardPorts": [
         3000
-    ]
+    ],
+    "postCreateCommand": ".devcontainer/postCreateCommand.sh"
 }

--- a/.devcontainer/mdbook-epub/devcontainer-feature.json
+++ b/.devcontainer/mdbook-epub/devcontainer-feature.json
@@ -1,0 +1,10 @@
+{
+    "name": "mdbook-epub",
+    "id": "mdbook-epub",
+    "version": "0.1.0",
+    "description": "Installs mdbook-epub for generating EPUB files from mdbook",
+    "options": {},
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/rust"
+    ]
+}

--- a/.devcontainer/mdbook-epub/install.sh
+++ b/.devcontainer/mdbook-epub/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Michael F. Collins, III
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNETION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+set -e
+
+cargo install --locked mdbook-epub

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,16 +1,11 @@
+#!/usr/bin/env sh
+
 # Copyright 2024 Michael F. Collins, III
 #
 # Building Microservices with Dapr © 2024 by Michael F. Collins, III is
 # licensed under CC BY-ND 4.0. To view a copy of this license, visit
 # https://creativecommons.org/licenses/by-nd/4.0/
 
-[book]
-authors = ["Michael Collins"]
-language = "en"
-multilingual = false
-src = "src"
-title = "Building Microservices with Dapr"
+set -e
 
-[output.html]
-
-[output.epub]
+git config --global --add safe.directory /workspaces/dapr-book

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,6 +41,8 @@ jobs:
           echo `pwd`/mdbook >> $GITHUB_PATH
         env:
           tag: ${{ env.MDBOOK_TAG }}
+      - name: Install mdbook-epub
+        run: cargo install mdbook-epub
       - name: Build the book
         run: mdbook build
       - name: Setup GitHub Pages
@@ -48,7 +50,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'book'
+          path: 'book/html'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,30 @@
 # https://creativecommons.org/licenses/by-nd/4.0/
 
 book
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
I added mdbook-epub to the project. mdbook-epub will extend mdbook to generate an ePUB version of the book that can be installed in a reader program such as Apple Books on the iPad or macOS.

I created a custom development container feature to install mdbook-epub and added it to the development container.